### PR TITLE
feat(completion): add run flags to Carapace spec

### DIFF
--- a/internal/carapace.go
+++ b/internal/carapace.go
@@ -142,6 +142,17 @@ func (g *carapaceSpecGenerator) GenerateYAMLSpec(cmd *cobra.Command) (string, er
 			},
 			"run": {
 				Description: "Run package.json scripts (equivalent to 'nr')",
+				Flags: map[string]FlagSpec{
+					"if-present": {
+						Description: "Run script only if it exists",
+					},
+					"auto-install": {
+						Description: "Auto-install deps when missing (effective default true for dev/start)",
+					},
+					"no-volta": {
+						Description: "Disable Volta integration during auto-install",
+					},
+				},
 				Completion:  "$carapace.scripts.npm",
 			},
 			"exec": {


### PR DESCRIPTION
# Pull Request

## Why
Expose the new run flags in shell completion so users discover and use them easily.

## What
- Add run flags to Carapace spec: --if-present, --auto-install, --no-volta.

## How
- Update internal/carapace.go generator to include flags in the run command spec.

## Breaking changes
- [x] None

## Tests
- Existing Carapace generator code remains covered; manual validation can be done by regenerating the spec.

## Checklist
- [x] Conventional commits
- [x] Atomic change, builds & tests pass locally
- [x] Targets develop with git-flow
