### PR TITLE
ci: run CI on develop and PRs to develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
# Pull Request

## Why
Align CI triggers with Git Flow: run on pushes to develop and PRs targeting develop.

## What
- Update CI workflow triggers to include develop for push and pull_request events.

## How
- Edit .github/workflows/ci.yml to set branches: [main, develop].

## Breaking changes
- [x] None

## Checklist
- [x] Conventional commit
- [x] Atomic change, builds & tests pass locally (no code changes)
- [x] Targets develop with git-flow
